### PR TITLE
json limit: increase the file size limit

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -73,7 +73,8 @@ app.use(
   "/",
   cors(corsOptions),
   cookieParser(),
-  bodyParser.json(),
+  bodyParser.json({limit: "50mb"}),
+  bodyParser.urlencoded({ limit: "50mb", extended: true, parameterLimit: 50000 }),
   expressjwt({
     secret: jwt_secret,
     algorithms: ["HS256"],


### PR DESCRIPTION
## Reason

- Since from the PR: https://github.com/Clubs-Council-IIITH/interfaces/pull/13 we are trying to send pdf files, we will have to increase the limit of json being sent

## Changes

Adds a bodyparser tags for json and urlencoders to allow 50mb